### PR TITLE
2306-build-system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/lib/**
+/obj/**
+/test/bin/**

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+CC=gcc
+CFLAGS=-g -Wall
+
+SRC=src
+SRCS=$(wildcard $(SRC)/*.c)
+OBJ=obj
+OBJS=$(patsubst $(SRC)/%.c, $(OBJ)/%.o, $(SRCS))
+
+TEST=test
+TESTS=$(wildcard $(TEST)/*.c)
+TESTRUNNER=$(TEST)/bin/test_runner
+
+LIBDIR=lib
+LIB=$(LIBDIR)/lib.a
+
+VALGRIND_LOG=valgrind.log
+
+####
+
+all: $(LIB)
+
+test: $(LIB) $(TEST)/bin $(TESTRUNNER)
+	@bash -c 'valgrind --trace-children=yes --leak-check=full ./$(TESTRUNNER) --color=always 2>&1 | tee >(grep -E "^\[") > $(VALGRIND_LOG)'
+	@grep "definitely lost: [1-9][0-9]* bytes in [1-9][0-9]* blocks" $(VALGRIND_LOG) || true
+
+clean:
+	$(RM) -r $(LIBDIR) $(OBJ) $(TEST)/bin $(VALGRIND_LOG)
+
+####
+
+$(LIB): $(LIBDIR) $(OBJ) $(OBJS)
+	$(RM) $(LIB)
+	ar -cvrs $(LIB) $(OBJS)
+
+$(OBJ)/%.o: $(SRC)/%.c 
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(TESTRUNNER): $(TESTS) $(OBJS)
+	$(CC) $(CFLAGS) $(TESTS) $(OBJS) -o $(TESTRUNNER) -lcriterion
+
+$(TEST)/bin:
+	mkdir $@
+
+$(OBJ):
+	mkdir $@
+
+$(LIBDIR):
+	mkdir $@

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # cii
-Following C Interfaces and Implmentations to learn C API design.
+Following C Interfaces and Implementations to learn C API design.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # cii
-Following C Interfaces and Implementations to learn C API design.
+
+Following C Interfaces and Implementations to learn C API design, C build systems and unit testing. 
+
+
+## TODO
+
+1. Rework all `malloc` calls with custom wrapper to gracefully handle failed allocations.
+2. Rework all `assert` calls with custom wrapper to gracefully handle failed library method invocations.

--- a/include/stack.h
+++ b/include/stack.h
@@ -1,0 +1,12 @@
+#ifndef STACK_H
+#define STACK_H
+
+typedef struct Stack_T *Stack;
+
+Stack   stack_create();
+int     stack_is_empty(Stack s);
+void    stack_push(Stack s, void *data);
+void   *stack_pop(Stack s);
+void    stack_free(Stack *s);
+
+#endif // STACK_H

--- a/src/stack.c
+++ b/src/stack.c
@@ -1,0 +1,79 @@
+#include "../include/stack.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct Stack_T {
+  int len;
+
+  struct node {
+    void *data;
+    struct node *next;
+  } *head;
+};
+
+Stack stack_create() {
+  Stack stk;
+
+  stk = (Stack)malloc(sizeof(struct Stack_T));
+  if (stk == NULL) {
+    return NULL;
+  }
+
+  stk->len = 0;
+  stk->head = NULL;
+  return stk;
+}
+
+int stack_is_empty(Stack stk) {
+  assert(stk);
+
+  return stk->len == 0;
+}
+
+void stack_push(Stack stk, void *data) {
+  struct node *new_head;
+
+  assert(stk);
+
+  new_head = (struct node *)malloc(sizeof(struct node));
+  if (new_head == NULL) {
+    return;
+  }
+
+  new_head->data = data;
+  new_head->next = stk->head;
+  stk->head = new_head;
+  stk->len++;
+}
+
+void *stack_pop(Stack stk) {
+  struct node *old_head;
+  void *inner_data;
+
+  assert(stk);
+  assert(stk->len > 0);
+
+  old_head = stk->head;
+  stk->head = old_head->next;
+  stk->len--;
+
+  inner_data = old_head->data;
+  free(old_head);
+  return inner_data;
+}
+
+void stack_free(Stack *stk) {
+  struct node *cur, *next;
+
+  assert(stk);
+  assert(*stk);
+
+  for (cur = (*stk)->head; cur != NULL; cur = next) {
+    next = cur->next;
+    free(cur);
+  }
+
+  free(*stk);
+  *stk = NULL;
+}

--- a/test/test_stack.c
+++ b/test/test_stack.c
@@ -1,0 +1,46 @@
+#include "../include/stack.h"
+#include <criterion/criterion.h>
+
+Test(stack, stack_create) {
+  Stack s = stack_create();
+
+  cr_assert_not_null(s);
+  cr_assert(stack_is_empty(s));
+
+  stack_free(&s);
+}
+
+Test(stack, stack_push_pop) {
+  Stack s = stack_create();
+
+  stack_push(s, (void*)1);
+  cr_assert_not(stack_is_empty(s));
+  cr_assert_eq((int *)stack_pop(s), 1);
+  cr_assert(stack_is_empty(s));
+
+  stack_free(&s);
+}
+
+Test(stack, stack_free) {
+  Stack s = stack_create();
+
+  stack_push(s, (void*)1);
+  stack_free(&s);
+
+  cr_assert_null(s);
+}
+
+// Test(stack, is_empty) {
+//     Stack s = stack_create();
+//     cr_assert(stack_is_empty(s), "Expected new stack to be empty");
+//
+//     int data = 42;
+//     stack_push(s, &data);
+//     cr_assert_not(stack_is_empty(s), "Expected stack not to be empty after
+//     push");
+//
+//     stack_pop(s);
+//     cr_assert(stack_is_empty(s), "Expected stack to be empty after pop");
+//
+//     stack_free(&s);
+// }

--- a/test/test_stack.c
+++ b/test/test_stack.c
@@ -13,7 +13,7 @@ Test(stack, stack_create) {
 Test(stack, stack_push_pop) {
   Stack s = stack_create();
 
-  stack_push(s, (void*)1);
+  stack_push(s, (void *)1);
   cr_assert_not(stack_is_empty(s));
   cr_assert_eq((int *)stack_pop(s), 1);
   cr_assert(stack_is_empty(s));
@@ -24,23 +24,8 @@ Test(stack, stack_push_pop) {
 Test(stack, stack_free) {
   Stack s = stack_create();
 
-  stack_push(s, (void*)1);
+  stack_push(s, (void *)1);
   stack_free(&s);
 
   cr_assert_null(s);
 }
-
-// Test(stack, is_empty) {
-//     Stack s = stack_create();
-//     cr_assert(stack_is_empty(s), "Expected new stack to be empty");
-//
-//     int data = 42;
-//     stack_push(s, &data);
-//     cr_assert_not(stack_is_empty(s), "Expected stack not to be empty after
-//     push");
-//
-//     stack_pop(s);
-//     cr_assert(stack_is_empty(s), "Expected stack to be empty after pop");
-//
-//     stack_free(&s);
-// }


### PR DESCRIPTION
Setup a build system and implement the stack ADT so there's something to build.

General idea is to compile a static libraries and then build tests against that library which run under valgrind to check for memory leaks. 

We need to trace all child processes to get checks on all the individual unit tests which clutters standard out. For this reason, a hack is applied which filters on `[` (the prefix of test outputs) between a val grind log file and standard out. If there is a memory leak in the tests, there will be a notification in standard out, and the file can be used to investigate further.